### PR TITLE
Use local encrypt keys map and update the DKG procedure flow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ repository = "https://github.com/maidsafe/BLS-DKG"
 version = "0.1.0"
 
 [dependencies]
+aes = "^0.3.2"
 bincode = "^1.1.4"
+block-modes = "^0.3.3"
 err-derive = "^0.2.4"
 itertools = "0.9.0"
 rand = "^0.7.3"

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -100,16 +100,6 @@ impl SecretId for PeerId {
     fn public_id(&self) -> &Self::PublicId {
         &self
     }
-
-    fn encrypt<M: AsRef<[u8]>>(&self, _to: &Self::PublicId, _msg: M) -> Option<Vec<u8>> {
-        // Pass through: Not being actually used within the crate.
-        None
-    }
-
-    fn decrypt(&self, _from: &Self::PublicId, _ct: &[u8]) -> Option<Vec<u8>> {
-        // Pass through: Not being actually used within the crate.
-        None
-    }
 }
 
 /// **NOT FOR PRODUCTION USE**: Returns a collection of mock node IDs with human-readable names.

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -101,16 +101,14 @@ impl SecretId for PeerId {
         &self
     }
 
-    fn encrypt<M: AsRef<[u8]>>(&self, _to: &Self::PublicId, msg: M) -> Option<Vec<u8>> {
-        // Pass through: We cannot store encryption keys as they are not reproductible.
-        // This code is only used for test.
-        Some(msg.as_ref().to_vec())
+    fn encrypt<M: AsRef<[u8]>>(&self, _to: &Self::PublicId, _msg: M) -> Option<Vec<u8>> {
+        // Pass through: Not being actually used within the crate.
+        None
     }
 
-    fn decrypt(&self, _from: &Self::PublicId, ct: &[u8]) -> Option<Vec<u8>> {
-        // Pass through: We cannot store encryption keys as they are not reproductible.
-        // This code is only used for test.
-        Some(ct.to_vec())
+    fn decrypt(&self, _from: &Self::PublicId, _ct: &[u8]) -> Option<Vec<u8>> {
+        // Pass through: Not being actually used within the crate.
+        None
     }
 }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -27,9 +27,4 @@ pub trait SecretId {
 
     /// Returns the associated public identity.
     fn public_id(&self) -> &Self::PublicId;
-
-    /// Encrypts the message using own Rng to `to`
-    fn encrypt<M: AsRef<[u8]>>(&self, to: &Self::PublicId, msg: M) -> Option<Vec<u8>>;
-    /// Decrypt message from `from`.
-    fn decrypt(&self, from: &Self::PublicId, ct: &[u8]) -> Option<Vec<u8>>;
 }

--- a/src/key_gen/encryptor.rs
+++ b/src/key_gen/encryptor.rs
@@ -1,0 +1,74 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use super::Error;
+use crate::id::PublicId;
+use aes::Aes128;
+use block_modes::block_padding::Pkcs7;
+use block_modes::{BlockMode, Cbc};
+use rand::Rng;
+use std::collections::{BTreeMap, BTreeSet};
+
+type Aes128Cbc = Cbc<Aes128, Pkcs7>;
+
+const KEY_SIZE: usize = 16;
+const IV_SIZE: usize = 16;
+
+pub struct Key(pub [u8; KEY_SIZE]);
+pub struct Iv(pub [u8; IV_SIZE]);
+
+fn encrypt(data: &[u8], key: &Key, iv: &Iv) -> Result<Vec<u8>, Error> {
+    let cipher =
+        Aes128Cbc::new_var(key.0.as_ref(), iv.0.as_ref()).map_err(|_e| Error::Encryption)?;
+    Ok(cipher.encrypt_vec(data))
+}
+
+// pub fn decrypt(encrypted_data: &[u8], key: &Key, iv: &Iv) -> Result<Vec<u8>, Error> {
+//     let cipher =
+//         Aes128Cbc::new_var(key.0.as_ref(), iv.0.as_ref()).map_err(|_err| Error::Encryption)?;
+//     cipher
+//         .decrypt_vec(encrypted_data)
+//         .map_err(|_err| Error::Encryption)
+// }
+
+/// An instance holds the encryption keys during the DKG procedure, and provides the encryption
+/// facilities.
+pub struct Encryptor<P: PublicId> {
+    keys_map: BTreeMap<P, (Key, Iv)>,
+}
+
+impl<P: PublicId> Encryptor<P> {
+    pub fn new(peers: &BTreeSet<P>) -> Self {
+        let mut keys_map = BTreeMap::new();
+        // let mut rng = rand::thread_rng();
+        // let mut rng_adaptor = RngAdapter(&mut rng);
+        for pk in peers.iter() {
+            let key = Key(rand::thread_rng().gen());
+            let iv = Iv(rand::thread_rng().gen());
+            let _ = keys_map.insert(pk.clone(), (key, iv));
+        }
+        Encryptor { keys_map }
+    }
+
+    pub fn encrypt<M: AsRef<[u8]>>(&self, to: &P, msg: M) -> Result<Vec<u8>, Error> {
+        if let Some((key, iv)) = self.keys_map.get(to) {
+            encrypt(msg.as_ref(), key, iv)
+        } else {
+            Err(Error::Encryption)
+        }
+    }
+
+    // pub fn decrypt(&self, from: &P, ct: &[u8]) -> Result<Vec<u8>, Error> {
+    //     if let Some((key, iv)) = self.keys_map.get(from) {
+    //         decrypt(ct, key, iv)
+    //     } else {
+    //         Err(Error::Encryption)
+    //     }
+    // }
+}

--- a/src/key_gen/encryptor.rs
+++ b/src/key_gen/encryptor.rs
@@ -13,6 +13,7 @@ use aes::Aes128;
 use block_modes::block_padding::Pkcs7;
 use block_modes::{BlockMode, Cbc};
 use rand::Rng;
+use serde_derive::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 type Aes128Cbc = Cbc<Aes128, Pkcs7>;
@@ -20,7 +21,10 @@ type Aes128Cbc = Cbc<Aes128, Pkcs7>;
 const KEY_SIZE: usize = 16;
 const IV_SIZE: usize = 16;
 
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Key(pub [u8; KEY_SIZE]);
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Iv(pub [u8; IV_SIZE]);
 
 fn encrypt(data: &[u8], key: &Key, iv: &Iv) -> Result<Vec<u8>, Error> {
@@ -62,6 +66,10 @@ impl<P: PublicId> Encryptor<P> {
         } else {
             Err(Error::Encryption)
         }
+    }
+
+    pub fn keys_map(&self) -> BTreeMap<P, (Key, Iv)> {
+        self.keys_map.clone()
     }
 
     // pub fn decrypt(&self, from: &P, ct: &[u8]) -> Result<Vec<u8>, Error> {

--- a/src/key_gen/message.rs
+++ b/src/key_gen/message.rs
@@ -7,10 +7,11 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::{Commitment, Part};
+use super::encryptor::{Iv, Key};
+use super::{Acknowledgment, Part};
 use crate::id::PublicId;
 use serde_derive::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 /// Messages used for running BLS DKG.
@@ -23,7 +24,7 @@ pub enum Message<P: PublicId> {
         n: usize,
         member_list: BTreeSet<P>,
     },
-    Contribution {
+    Proposal {
         key_gen_id: u64,
         part: Part,
     },
@@ -34,11 +35,11 @@ pub enum Message<P: PublicId> {
     },
     Justification {
         key_gen_id: u64,
-        part: Part,
+        keys_map: BTreeMap<P, (Key, Iv)>,
     },
-    Commitment {
+    Acknowledgment {
         key_gen_id: u64,
-        commitment: Commitment,
+        ack: Acknowledgment,
     },
 }
 
@@ -48,15 +49,13 @@ impl<P: PublicId> fmt::Debug for Message<P> {
             Message::Initialization { key_gen_id, .. } => {
                 write!(formatter, "Initialization({})", key_gen_id)
             }
-            Message::Contribution { key_gen_id, .. } => {
-                write!(formatter, "Contribution({})", key_gen_id)
-            }
+            Message::Proposal { key_gen_id, .. } => write!(formatter, "Proposal({})", key_gen_id),
             Message::Complaint { key_gen_id, .. } => write!(formatter, "Complaint({})", key_gen_id),
             Message::Justification { key_gen_id, .. } => {
                 write!(formatter, "Justification({})", key_gen_id)
             }
-            Message::Commitment { key_gen_id, .. } => {
-                write!(formatter, "Commitment({})", key_gen_id)
+            Message::Acknowledgment { key_gen_id, .. } => {
+                write!(formatter, "Acknowledgment({})", key_gen_id)
             }
         }
     }

--- a/src/key_gen/tests.rs
+++ b/src/key_gen/tests.rs
@@ -93,7 +93,7 @@ fn having_max_unresponsive_nodes_still_work() {
     let (peer_ids, mut generators) = setup_generators(&mut rng, non_responsives.clone());
 
     let mut proposals = Vec::new();
-    // With one non_responsive node, Contribution phase cannot be completed automatically. This
+    // With one non_responsive node, Proposal phase cannot be completed automatically. This
     // requires finalize_contributing_phase to be called externally to complete the procedure.
     // All participants will transit into Complaint phase afterwards, Then requires
     // finalize_complaining_phase to be called externally to complete the procedure.
@@ -142,11 +142,11 @@ fn having_min_unresponsive_nodes_cause_block() {
     let (peer_ids, mut generators) = setup_generators(&mut rng, non_responsives.clone());
 
     // The `messaging` function only ignores the non-initial proposals from a non-responsive node.
-    // i.e. the Initialization phase will be completed and transits into Contribution.
+    // i.e. the Initialization phase will be completed and transits into Proposal.
     // With more non-responsive nodes, `finalize_contributing_phase` returns with Complaints of
     // non-contributors, and trigger the transition into Complaint phase. However, the Complaint
     // phase will be blocked as cannot collect more than thresold votes.
-    // And the phase shall be blocked at Contribution.
+    // And the phase shall be blocked at Proposal.
     let mut proposals = Vec::new();
 
     // Trigger `finalize_contributing_phase` first, and exchange complaints


### PR DESCRIPTION
This work contains the work of:
1, Use local encryption key per peer for the DKG proposals. Which eliminates the limitation to the secert key, that it has to record per peer's encryption key.
2, Changes to make the Contribution phase collect all proposed commitments and acks. And the Commitment phase do the same within a new round of DKG that having invalid members removed.
    The Justification phase is aimed to allow the complained member to convice others to recover.
    However this step may not be needed, and requiring a further investigation.