### PR TITLE
chore(cargo): remove cargo.toml documentation line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Implementation of a DKG"
-documentation = ""
 edition = "2018"
 exclude = [""]
 homepage = "https://maidsafe.net"


### PR DESCRIPTION
This line is an empty set of quotes ("") and is causing the publish
to fail. Other similar crates don't have this documentation line
so removing and will publish docs separately.