### PR TITLE
chore(cd): add continuous delivery and auto merge dependabot PRs

### DIFF
--- a/.github/workflows/auto_merge_prs.yml
+++ b/.github/workflows/auto_merge_prs.yml
@@ -1,0 +1,37 @@
+# auto merge workflow.
+#
+# Auto merge PR if commit msg begins with `chore(release):`,
+# or if it has been raised by Dependabot.
+# Uses https://github.com/ridedott/merge-me-action.
+
+name: Merge Version Change and Dependabot PRs automatically
+
+on: pull_request
+
+jobs:
+  merge:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+
+    - name: get commit message
+      run: |
+           echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }})
+    - name: show commit message
+      run : echo $commitmsg
+
+    - name: Merge Version change PR
+      if: startsWith( env.commitmsg, 'chore(release):')
+      uses: ridedott/merge-me-action@81667e6ae186ddbe6d3c3186d27d91afa7475e2c
+      with:
+        GITHUB_LOGIN: dirvine
+        GITHUB_TOKEN: ${{ secrets.MERGE_BUMP_BRANCH_TOKEN }}
+        MERGE_METHOD: REBASE
+
+    - name: Dependabot Merge
+      uses: ridedott/merge-me-action@master
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MERGE_METHOD: REBASE

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,24 @@
+name: Version bump and create PR for changes
+
+on:
+  # Trigger the workflow on push only for the master branch
+  push:
+    branches:
+      - master
+
+env:
+  NODE_ENV: 'development'
+
+jobs:
+  update_changelog:
+    runs-on: ubuntu-20.04
+    # Dont run if we're on a release commit
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Bump Version
+        uses: maidsafe/rust-version-bump-branch-creator@v2
+        with:
+          token: ${{ secrets.BRANCH_CREATOR_TOKEN }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,13 @@
+name: Commitlint
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@f114310111fdbd07e99f47f9ca13d62b3ec98372

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,0 +1,37 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    # only if we have a tag
+    name: Release
+    runs-on: ubuntu-20.04
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+
+      - name: Set tag as env
+        shell: bash
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+
+      - name: lets check tag
+        shell: bash
+        run: echo ${{ env.RELEASE_VERSION }}
+
+      - name: Generate Changelog
+        shell: bash
+        run: awk '/# \[/{c++;p=1}{if(c==2){exit}}p;' CHANGELOG.md > RELEASE-CHANGELOG.txt
+      - run: cat RELEASE-CHANGELOG.txt
+      - name: Release generation
+        uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_BUMP_BRANCH_TOKEN }}
+        with:
+          body_path: RELEASE-CHANGELOG.txt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,78 @@
+# Push to master workflow.
+#
+# Runs when a PR has been merged to the master branch.
+#
+# 1. Generates a release build.
+# 2. If the last commit is a version change, publish.
+
+name: Master
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  # Run all cargo commands with --verbose.
+  CARGO_TERM_VERBOSE: true
+  RUST_BACKTRACE: 1
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
+      # Cache.
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+
+      # Make sure the code builds.
+      - name: Cargo Build
+        run: cargo build --release
+
+  # Publish if we're on a release commit
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: build
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+    steps:
+      - uses: actions/checkout@v2
+      # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
+        with:
+          fetch-depth: '0'
+     
+      # Install Rust
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Publish to crates.io.
+      - name: Cargo Login
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+
+      - name: Cargo Publish
+        run: cargo publish

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,3 +127,20 @@ jobs:
       # Run tests.
       - shell: bash
         run: ./scripts/tests
+
+  # Test publish using --dry-run.
+  test-publish:
+    name: Test Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Cargo publish dry run
+      - name: Cargo Publish Dry Run
+        run: cargo publish --dry-run

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,37 @@
+name: Tag release commit
+
+on:
+  # Trigger the workflow on push only for the master branch
+  push:
+    branches:
+      - master
+
+env:
+  NODE_ENV: 'development'
+  GITHUB_TOKEN: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+
+jobs:
+  tag:
+      runs-on: ubuntu-latest
+      # Only run on a release commit
+      if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: '0'
+            token: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+        - run: echo ::set-env name=RELEASE_VERSION::$(git log -1 --pretty=%B)
+        # parse out non-tag text
+        - run: echo ::set-env name=RELEASE_VERSION::$( echo $RELEASE_VERSION | sed 's/chore(release)://' )
+        # remove spaces, but add back in `v` to tag, which is needed for standard-version
+        - run: echo ::set-env name=RELEASE_VERSION::v$(echo $RELEASE_VERSION | tr -d '[:space:]')
+        - run: echo $RELEASE_VERSION
+        - run: git tag $RELEASE_VERSION
+
+        - name: Setup git for push
+          run: |
+            git remote add github "$REPO"
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+        - name: Push tags to master
+          run: git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" HEAD:master --tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
-# bls_dkg - Change Log
-## [0.1.0]
-- Initial implementation
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [0.1.0](https://github.com/maidsafe/bls_dkg/compare/v0.1.0...v0.1.0) (2020-08-31)
+* Initial implementation


### PR DESCRIPTION
Implement a CD process where any PR merged to master will
automatically trigger a crate publish, a tag, a 'chore(release):'
PR which is auto merged, and a GitHub release.
This PR also adds auto merging for dependabot PRs which pass CI.
This PR also reformats the changelog to match the newly auto
generated format.