### PR TITLE
feat: using XorName as participants key

### DIFF
--- a/src/key_gen/mod.rs
+++ b/src/key_gen/mod.rs
@@ -1006,7 +1006,7 @@ impl Debug for KeyGen {
 
 #[cfg(test)]
 impl KeyGen {
-    /// Returns the list of the final participants.
+    /// Returns the name list of the final participants.
     pub fn names(&self) -> &BTreeSet<XorName> {
         &self.names
     }


### PR DESCRIPTION
BREAKING CHANGE: the commit before changed API to use XorName as
participants indexing key, instead of generic type with traits.
This commit is just to trigger a major version update.