### PR TITLE
chore(cd): replace deprecated `set-env` in CD pipeline

### DIFF
--- a/.github/workflows/auto_merge_prs.yml
+++ b/.github/workflows/auto_merge_prs.yml
@@ -18,7 +18,9 @@ jobs:
 
     - name: get commit message
       run: |
-           echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }})
+        commitmsg=$(git log --format=%s -n 1 ${{ github.event.pull_request.head.sha }})
+        echo "commitmsg=${commitmsg}" >> $GITHUB_ENV
+
     - name: show commit message
       run : echo $commitmsg
 

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,5 +1,6 @@
 name: Create GitHub Release
 
+
 on:
   push:
     tags:
@@ -19,7 +20,7 @@ jobs:
 
       - name: Set tag as env
         shell: bash
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+        run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
 
       - name: lets check tag
         shell: bash

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -40,6 +40,8 @@ jobs:
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2
+        # TODO: temporarily disable cache on macos due to weird issues with serde_derive crate. Needs further investigation.
+        if: matrix.os != 'macOS-latest'
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -135,6 +135,8 @@ jobs:
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2
+        # TODO: temporarily disable cache on macos due to weird issues with serde_derive crate. Needs further investigation.
+        if: matrix.os != 'macOS-latest'
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -20,11 +20,11 @@ jobs:
           with:
             fetch-depth: '0'
             token: ${{ secrets.BRANCH_CREATOR_TOKEN }}
-        - run: echo ::set-env name=RELEASE_VERSION::$(git log -1 --pretty=%B)
+        - run: echo "RELEASE_VERSION=$(git log -1 --pretty=%s)" >> $GITHUB_ENV
         # parse out non-tag text
-        - run: echo ::set-env name=RELEASE_VERSION::$( echo $RELEASE_VERSION | sed 's/chore(release)://' )
+        - run: echo "RELEASE_VERSION=$( echo $RELEASE_VERSION | sed 's/chore(release)://' )" >> $GITHUB_ENV
         # remove spaces, but add back in `v` to tag, which is needed for standard-version
-        - run: echo ::set-env name=RELEASE_VERSION::v$(echo $RELEASE_VERSION | tr -d '[:space:]')
+        - run: echo "RELEASE_VERSION=v$(echo $RELEASE_VERSION | tr -d '[:space:]')" >> $GITHUB_ENV
         - run: echo $RELEASE_VERSION
         - run: git tag $RELEASE_VERSION
 


### PR DESCRIPTION
`set-env` deprecated as of Nov 16th