### PR TITLE
chore(ci): add cargo deny check to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,6 +113,17 @@ jobs:
           cargo install cargo-udeps --locked
           cargo +nightly udeps --all-targets
 
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # wget the shared deny.toml file from the QA repo
+    - shell: bash
+      run: wget https://raw.githubusercontent.com/maidsafe/QA/master/misc-scripts/deny.toml
+
+    - uses: EmbarkStudios/cargo-deny-action@v1
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This fetches a shared deny.toml from the QA repo before running the cargo deny GH Action.