### PR TITLE
Support BLS keys with a single owner

### DIFF
--- a/src/key_gen/message.rs
+++ b/src/key_gen/message.rs
@@ -15,8 +15,8 @@ use std::fmt;
 use xor_name::XorName;
 
 /// Messages used for running BLS DKG.
-#[serde(bound = "")]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub enum Message {
     Initialization {
         key_gen_id: u64,

--- a/src/key_gen/mod.rs
+++ b/src/key_gen/mod.rs
@@ -31,8 +31,9 @@ use threshold_crypto::{
     group::CurveAffine,
     poly::{BivarCommitment, BivarPoly, Poly},
     serde_impl::FieldWrap,
-    Fr, G1Affine, SecretKeyShare,
+    Fr, G1Affine,
 };
+pub use threshold_crypto::{PublicKeySet, SecretKeyShare};
 use xor_name::XorName;
 
 /// A local error while handling a message, that was not caused by that message being invalid.

--- a/src/key_gen/mod.rs
+++ b/src/key_gen/mod.rs
@@ -206,15 +206,14 @@ impl InitializationAccumulator {
         }
 
         let paras = (m, n, member_list);
-        if let Some(value) = self.initializations.get_mut(&paras) {
-            *value += 1;
-            if *value >= m {
-                return Some(paras);
-            }
+        let value = self.initializations.entry(paras.clone()).or_insert(0);
+        *value += 1;
+
+        if *value >= m {
+            Some(paras)
         } else {
-            let _ = self.initializations.insert(paras, 1);
+            None
         }
-        None
     }
 }
 

--- a/src/key_gen/mod.rs
+++ b/src/key_gen/mod.rs
@@ -390,7 +390,7 @@ impl KeyGen {
     }
 
     fn poll_pending_messages<R: RngCore>(&mut self, rng: &mut R) -> Vec<Message> {
-        let pending_messages = std::mem::replace(&mut self.pending_messages, Vec::new());
+        let pending_messages = std::mem::take(&mut self.pending_messages);
         let mut msgs = Vec::new();
         for message in pending_messages {
             if let Ok(new_messages) = self.process_message(rng, message.clone()) {

--- a/src/key_gen/outcome.rs
+++ b/src/key_gen/outcome.rs
@@ -8,7 +8,8 @@
 // Software.
 
 use std::fmt::{self, Debug, Formatter};
-use threshold_crypto::{PublicKeySet, SecretKeyShare};
+
+use crate::{PublicKeySet, SecretKeyShare};
 
 #[derive(Clone)]
 /// DKG result

--- a/src/key_gen/tests.rs
+++ b/src/key_gen/tests.rs
@@ -80,7 +80,7 @@ fn messaging<R: RngCore>(
     // Keep broadcasting the proposals among the generators till no more.
     // The proposal from non_responsive nodes shall be ignored.
     while !proposals.is_empty() {
-        let proposals_local = std::mem::replace(proposals, Vec::new());
+        let proposals_local = std::mem::take(proposals);
         for proposal in &proposals_local {
             for (index, generator) in generators.iter_mut().enumerate() {
                 if let Ok(proposal_vec) = generator.handle_message(&mut rng, proposal.clone()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ extern crate serde_derive;
 extern crate log;
 
 pub mod key_gen;
+pub use key_gen::*;
 
 #[cfg(test)]
 mod dev_utils;


### PR DESCRIPTION
Currently we can't get past the initialization stage if you set a threshold of 0 or 1 since we don't check thresholds on the first message.