### PR TITLE
chore: bump blsttc dep to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BLS DKG
 
-Implementation of a BLS DKG mechanism, requires signing key, encryption key and SocketAddr of participants
+Implementation of a BLS DKG mechanism, requires signing key, encryption key and SocketAddr of participants.
 
 Based on the excellent description as found [here](https://github.com/dashpay/dips/blob/master/dip-0006/bls_m-of-n_threshold_scheme_and_dkg.md#distributed-key-generation-dkg-protocol). This implementation forces participation and honesty. Therefore it can be used in hostile and friendly environments where `m` must be `<=n`. The participant IDs must be sortable to allow all participants to select the same (threshold + 1) `t+1` participants in key generation.
 


### PR DESCRIPTION
BREAKING CHANGE: this commit just changes the README to force through a new version that will bump the version number correctly.

I'm using the title of the previous commit to indicate that that's where the relevant change is for the new release.