### PR TITLE
chore: bump xor_name from 3.0.0 to 4.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand_core = "~0.5.1"
 serde = "1.0.106"
 serde_derive = "1.0.106"
 thiserror = "1.0.23"
-xor_name = "3.0.0"
+xor_name = "4.0.0"
 
   [dependencies.tiny-keccak]
   version = "2.0.2"
@@ -30,3 +30,4 @@ xor_name = "3.0.0"
 [dev-dependencies]
 anyhow = "1"
 itertools = "~0.9.0"
+rand8 = {package="rand", version="0.8.5"}

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -29,9 +29,8 @@ pub struct PeerId {
 impl PeerId {
     pub fn new() -> Self {
         let (public_key, secret_key) = gen_keypair();
-        let mut rng = rand::thread_rng();
         Self {
-            id: rng.gen(),
+            id: rand8::random(),
             public_key,
             secret_key,
         }


### PR DESCRIPTION
this is needed to make safe_network build with xor_name 4.0.0.