### PR TITLE
chore: bump xor_name from 3.0.0 to 4.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand_core = "~0.5.1"
 serde = "1.0.106"
 serde_derive = "1.0.106"
 thiserror = "1.0.23"
-xor_name = "3.0.0"
+xor_name = "4.0.1"
 
   [dependencies.tiny-keccak]
   version = "2.0.2"

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -29,9 +29,8 @@ pub struct PeerId {
 impl PeerId {
     pub fn new() -> Self {
         let (public_key, secret_key) = gen_keypair();
-        let mut rng = rand::thread_rng();
         Self {
-            id: rng.gen(),
+            id: XorName(rand::random()),
             public_key,
             secret_key,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,5 +21,10 @@ extern crate log;
 pub mod key_gen;
 pub use key_gen::*;
 
+// export these because they are used in our public API.
+pub use blsttc;
+pub use rand_core;
+pub use xor_name;
+
 #[cfg(test)]
 mod dev_utils;


### PR DESCRIPTION
also re-export crates that are used in our public API

(this is needed to make safe_network build with xor_name 4.0.0.)